### PR TITLE
TES tags support + Configurable polling interval + Log request URL on error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,28 @@ process.executor = 'tes'
 > 
 > For example, if your TES endpoint is located in Azure and uses Azure Blob storage to store the work directory, you still need to provide the necessary Azure credentials for Nextflow to access the Blob storage.
 
-## Examples
+## Configuration
+
+```groovy
+plugins {
+    id 'nf-ga4gh'
+}
+process {
+    executor = 'tes'
+    container = 'quay.io/nextflow/bash'
+}
+tes {
+    // See `Authentication` section
+    endpoint = 'http://localhost:8000'
+    // Override the default 10s timeout
+    timeout = 30
+    // TES task tags
+    tags {
+        tag1 = 'abc'
+        tag2 = 'xyz'
+    }
+}
+```
 
 ### Endpoint
 
@@ -76,7 +97,7 @@ tes {
 }
 ```
 
-### TES Server
+## TES Server
 
 You can deploy a local [Funnel](https://ohsu-comp-bio.github.io/funnel) server using the following commands:
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ tes {
     // Override the default request timeout (10s)
     timeout = 30
 
-    // Override the default task polling interval (50ms)
-    pollInterval = '5s'
+    // Override the default task polling interval (5s)
+    pollInterval = '10s'
 
     // TES task tags
     tags {

--- a/README.md
+++ b/README.md
@@ -43,8 +43,13 @@ process {
 tes {
     // See `Authentication` section
     endpoint = 'http://localhost:8000'
-    // Override the default 10s timeout
+
+    // Override the default request timeout (10s)
     timeout = 30
+
+    // Override the default task polling interval (50ms)
+    pollInterval = '5s'
+
     // TES task tags
     tags {
         tag1 = 'abc'

--- a/src/main/groovy/nextflow/ga4gh/tes/client/ApiClient.java
+++ b/src/main/groovy/nextflow/ga4gh/tes/client/ApiClient.java
@@ -833,7 +833,8 @@ public class ApiClient {
         try {
             Field field = Call.class.getDeclaredField("originalRequest");
             field.setAccessible(true);
-            requestUrl = ((Request) field.get(call)).urlString();
+            Request request = ((Request) field.get(call));
+            requestUrl = request.method().toUpperCase() + " " + request.urlString();
         } catch (NoSuchFieldException | IllegalAccessException e) {
             System.out.println("Unable to get request URL: " + e);
         }

--- a/src/main/groovy/nextflow/ga4gh/tes/client/ApiClient.java
+++ b/src/main/groovy/nextflow/ga4gh/tes/client/ApiClient.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.net.URLConnection;
 import java.net.URLEncoder;
@@ -827,6 +828,18 @@ public class ApiClient {
             return Files.createTempFile(Paths.get(tempFolderPath), prefix, suffix).toFile();
     }
 
+    private String getRequestUrl(Call call) {
+        String requestUrl = "<unknown>";
+        try {
+            Field field = Call.class.getDeclaredField("originalRequest");
+            field.setAccessible(true);
+            requestUrl = ((Request) field.get(call)).urlString();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            System.out.println("Unable to get request URL: " + e);
+        }
+        return requestUrl;
+    }
+
     /**
      * {@link #execute(Call, Type)}
      *
@@ -851,12 +864,13 @@ public class ApiClient {
      * @throws ApiException If fail to execute the call
      */
     public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
+        String requestUrl = getRequestUrl(call);
         try {
             Response response = call.execute();
-            T data = handleResponse(response, returnType);
+            T data = handleResponse(response, returnType, requestUrl);
             return new ApiResponse<T>(response.code(), response.headers().toMultimap(), data);
         } catch (IOException e) {
-            throw new ApiException(e);
+            throw new ApiException("Error during request to '" + requestUrl + "': " + e);
         }
     }
 
@@ -882,17 +896,18 @@ public class ApiClient {
      */
     @SuppressWarnings("unchecked")
     public <T> void executeAsync(Call call, final Type returnType, final ApiCallback<T> callback) {
+        String requestUrl = getRequestUrl(call);
         call.enqueue(new Callback() {
             @Override
             public void onFailure(Request request, IOException e) {
-                callback.onFailure(new ApiException(e), 0, null);
+                callback.onFailure(new ApiException("Error during request to '" + requestUrl + "': " + e), 0, null);
             }
 
             @Override
             public void onResponse(Response response) throws IOException {
                 T result;
                 try {
-                    result = (T) handleResponse(response, returnType);
+                    result = (T) handleResponse(response, returnType, requestUrl);
                 } catch (ApiException e) {
                     callback.onFailure(e, response.code(), response.headers().toMultimap());
                     return;
@@ -912,7 +927,7 @@ public class ApiClient {
      *   fail to deserialize the response body
      * @return Type
      */
-    public <T> T handleResponse(Response response, Type returnType) throws ApiException {
+    public <T> T handleResponse(Response response, Type returnType, String requestUrl) throws ApiException {
         if (response.isSuccessful()) {
             if (returnType == null || response.code() == 204) {
                 // returning null if the returnType is not defined,
@@ -934,10 +949,10 @@ public class ApiClient {
                 try {
                     respBody = response.body().string();
                 } catch (IOException e) {
-                    throw new ApiException(response.message(), e, response.code(), response.headers().toMultimap());
+                    throw new ApiException("Error during request to '" + requestUrl + "': " + response.message(), e, response.code(), response.headers().toMultimap());
                 }
             }
-            throw new ApiException(response.message(), response.code(), response.headers().toMultimap(), respBody);
+            throw new ApiException("Error during request to '" + requestUrl + "': " + response.message(), response.code(), response.headers().toMultimap(), respBody);
         }
     }
 

--- a/src/main/groovy/nextflow/ga4gh/tes/executor/TesExecutor.groovy
+++ b/src/main/groovy/nextflow/ga4gh/tes/executor/TesExecutor.groovy
@@ -147,6 +147,11 @@ class TesExecutor extends Executor implements ExtensionPoint {
         return storageAccount
     }
 
+    protected Map<String,String> getTags() {
+        final Map<String,String> result = session.config.navigate('tes.tags') as Map
+        return result
+    }
+
     /**
      * @return {@code true} whenever the containerization is managed by the executor itself
      */

--- a/src/main/groovy/nextflow/ga4gh/tes/executor/TesExecutor.groovy
+++ b/src/main/groovy/nextflow/ga4gh/tes/executor/TesExecutor.groovy
@@ -170,7 +170,7 @@ class TesExecutor extends Executor implements ExtensionPoint {
      * @return the task monitor instance
      */
     TaskMonitor createTaskMonitor() {
-        final pollInterval = session.config.navigate('tes.pollInterval', '50ms') as String;
+        final pollInterval = session.config.navigate('tes.pollInterval', '5s') as String;
         TaskMonitor tpm = TaskPollingMonitor.create(session, config, name, 5, Duration.of(pollInterval));
         log.debug "Initialized task polling monitor (polling interval: ${pollInterval})";
         return tpm;

--- a/src/main/groovy/nextflow/ga4gh/tes/executor/TesExecutor.groovy
+++ b/src/main/groovy/nextflow/ga4gh/tes/executor/TesExecutor.groovy
@@ -165,7 +165,10 @@ class TesExecutor extends Executor implements ExtensionPoint {
      * @return the task monitor instance
      */
     TaskMonitor createTaskMonitor() {
-        return TaskPollingMonitor.create(session, config, name, 5, Duration.of('50ms'))
+        final pollInterval = session.config.navigate('tes.pollInterval', '50ms') as String;
+        TaskMonitor tpm = TaskPollingMonitor.create(session, config, name, 5, Duration.of(pollInterval));
+        log.debug "Initialized task polling monitor (polling interval: ${pollInterval})";
+        return tpm;
     }
 
     /*

--- a/src/main/groovy/nextflow/ga4gh/tes/executor/TesExecutor.groovy
+++ b/src/main/groovy/nextflow/ga4gh/tes/executor/TesExecutor.groovy
@@ -148,7 +148,12 @@ class TesExecutor extends Executor implements ExtensionPoint {
     }
 
     protected Map<String,String> getTags() {
-        final Map<String,String> result = session.config.navigate('tes.tags') as Map
+        // Explicitly convert the values to String to allow passing tags through environment
+        // variables, e.g. `tes { tags { MY_VAR = "${MY_VAR}" } }`. Env var values are otherwise of
+        // GString type and cause the error `class org.codehaus.groovy.runtime.GStringImpl cannot
+        // be cast to class java.lang.String`.
+        final Map<String,String> result = (session.config.navigate('tes.tags') as Map)
+    ?.collectEntries { k, v -> [k.toString(), v.toString()] }
         return result
     }
 

--- a/src/main/groovy/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/src/main/groovy/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -239,6 +239,7 @@ class TesTaskHandler extends TaskHandler {
         }
 
         body.setName(task.getName())
+        body.setTags(executor.getTags())
 
         // add the executor
         body.executors = List.of(exec)


### PR DESCRIPTION
- Pass any configured tags to the TES backend.
- Log the request URL when an API call errors to facilitate debugging. Example: `Error during request to 'POST http://tes-server/ga4gh/tes/v1/tasks': Unauthorized`
- Configurable polling interval
- I updated the readme to add a sample nextflow configuration file. The `tags` setting is added in this PR and the `timeout` setting is from https://github.com/nextflow-io/nf-ga4gh/pull/17.