### PR TITLE
fix: Update TES Server installation URL in `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install TES Server
         run: |
           # https://github.com/ohsu-comp-bio/funnel/releases/tag/v0.11.8
-          curl -fsSL https://ohsu-comp-bio.github.io/funnel/install.sh | bash -s -- v0.11.8
+          curl -fsSL https://calypr.github.io/funnel/install.sh | bash -s -- v0.11.8
 
       - name: Start TES Server
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,12 +84,28 @@ jobs:
 
       - name: Install TES Server
         run: |
-          # https://github.com/ohsu-comp-bio/funnel/releases/tag/v0.11.8
-          curl -fsSL https://calypr.github.io/funnel/install.sh | bash -s -- v0.11.8
+          # Pinning install script below to stable commit for security/reproducibility
+          # Ref: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
+          # Release: https://github.com/calypr/funnel/releases/tag/v0.11.8
+
+          INSTALL_SCRIPT=https://raw.githubusercontent.com/calypr/funnel/4103475e492dec1fd853e9863d0caad15fc504c0/install.sh
+          curl -fsSL $INSTALL_SCRIPT | bash -s -- v0.11.8
 
       - name: Start TES Server
         run: |
-          funnel server run > funnel.log 2>&1 &
+          set -euo pipefail
+          nohup funnel server run > funnel.log 2>&1 &
+          echo $! > funnel.pid
+          for i in $(seq 1 10); do
+            if curl -fsS http://localhost:8000/ >/dev/null 2>&1; then
+              echo "Funnel server started"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Funnel server failed to start!"
+          cat funnel.log
+          exit 1
 
       - name: Get plugin version
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,9 @@ jobs:
           }
           process {
               executor = 'tes'
-              container = 'ubuntu:latest'
+              // Pinning to recent LTS release for stability/security
+              // See:https://github.com/nextflow-io/nextflow/issues/7114
+              container = 'ubuntu:24.04'
           }
           params {
               // TES
@@ -131,8 +133,8 @@ jobs:
               basicUsername              = null
               basicPassword              = null
           }
-          // report.enabled = true
-          // timeline.enabled = true
+          report.enabled = true
+          timeline.enabled = true
           EOF
 
       - name: Run nf-canary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           nohup funnel server run > funnel.log 2>&1 &
           echo $! > funnel.pid
           for i in $(seq 1 10); do
-            if curl -fsS http://localhost:8000/ >/dev/null 2>&1; then
+            if curl -fsS http://localhost:8000/service-info >/dev/null 2>&1; then
               echo "Funnel server started"
               exit 0
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,9 @@ jobs:
           timeline.enabled = true
           EOF
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Run nf-canary
         run: |
           export NXF_ANSI_LOG=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,12 +131,9 @@ jobs:
               basicUsername              = null
               basicPassword              = null
           }
-          report.enabled = true
-          timeline.enabled = true
+          // report.enabled = true
+          // timeline.enabled = true
           EOF
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: Run nf-canary
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,6 @@ jobs:
           process {
               executor = 'tes'
               // Pinning to recent LTS release for stability/security
-              // See:https://github.com/nextflow-io/nextflow/issues/7114
               container = 'ubuntu:24.04'
           }
           params {


### PR DESCRIPTION
# Overview 🌀

This PR includes the following updates to unblock the nf-canary tests in [`build.yml`](https://github.com/nextflow-io/nf-ga4gh/pull/20/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721) (preventing [recent PR's](https://github.com/nextflow-io/nf-ga4gh/pulls) from running successfully).

- Updated [Funnel installation script](https://github.com/nextflow-io/nf-ga4gh/pull/20/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R87-R92) source (due to organization change)

- Pinned [executor container](https://github.com/nextflow-io/nf-ga4gh/pull/20/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R126-R127) to `ubuntu:24.04` to avoid trace errors outlined in [Nextflow Issue #7114](https://github.com/nextflow-io/nextflow/issues/7114) + addressed in [PR #7118](https://github.com/nextflow-io/nextflow/pull/7118)

## Current Behavior ❌

> [!CAUTION]
>
> Failing nf-canary tests ([example](https://github.com/nextflow-io/nf-ga4gh/actions/runs/25526069086))

<a href="https://github.com/nextflow-io/nf-ga4gh/actions/runs/25526069086">
  <img width="679" height="271" alt="Failing GitHub Action" src="https://github.com/user-attachments/assets/a77d2a37-f729-4bf2-8b39-38881400a94d" />
</a>

## New Behavior ✔

> [!TIP]
>
> nf-canary tests passing ([example](https://github.com/nextflow-io/nf-ga4gh/actions/runs/25525760523))

<a href="https://github.com/nextflow-io/nf-ga4gh/actions/runs/25525760523">
  <img width="679" height="271" alt="Passing GitHub Action" src="https://github.com/user-attachments/assets/ca151801-79e5-4446-b6fc-789d410a5b4a" />
</a>