### PR TITLE
hotfix: Correct tes config block in e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,8 +119,7 @@ jobs:
               // Pinning to recent LTS release for stability/security
               container = 'ubuntu:24.04'
           }
-          params {
-              // TES
+          tes {
               endpoint                   = 'http://localhost:8000'
               basicUsername              = null
               basicPassword              = null


### PR DESCRIPTION
# Overview 🌀

This PR fixes the `nextflow.config` generated by the e2e tests so that the TES connectivity settings live under the `tes { }` config scope instead of `params { }`.

## Current Behavior

- The e2e test config places `endpoint`, `basicUsername`, and `basicPassword` inside a `params { }` block.
- `TesExecutor` reads these via `session.config.navigate('tes.endpoint')` (and `tes.basicUsername` / `tes.basicPassword`), so values under `params` are silently ignored.
- The test only passed because `tes.endpoint` falls back to its default of `http://localhost:8000` — the configured values were never actually exercised.

## New Behavior ✔️

- The settings are moved into a `tes { }` block, matching the scope the executor reads from and the example in the README.
- The e2e test now exercises the real `tes.*` config path, so basic auth and a non-default endpoint would be respected.

## Breaking Changes? ❌

- [x] No, just fixing tests in GitHub Actions